### PR TITLE
Fix up the build infrastructure to succeed on a clean machine

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -109,6 +109,9 @@ try {
       }
     }
 
+    $VcpkgNovelRTBuildTreeDir = Join-Path -Path $VcpkgInstallDir -ChildPath "buildtrees/novelrt"
+    Create-Directory -Path $VcpkgNovelRTBuildTreeDir
+
     & $VcpkgExe install novelrt --triplet x64-windows --head
 
     if ($LastExitCode -ne 0) {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -176,6 +176,9 @@ if $ci; then
     fi
   fi
 
+  VcpkgNovelRTBuildTreeDir="$VcpkgInstallDir/buildtrees/novelrt"
+  CreateDirectory "$VcpkgNovelRTBuildTreeDir"
+
   "$VcpkgExe" install novelrt --head
   LASTEXITCODE=$?
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,5 +50,5 @@ install(TARGETS TouhouNovelRT
 )
 
 install(DIRECTORY "$<TARGET_FILE_DIR:TouhouNovelRT>/Resources"
-        DESTINATION bin/Resources
+        DESTINATION bin
 )


### PR DESCRIPTION
This fixes the build scripts to ensure the `buildtrees/novelrt` folder exists prior to having vcpkg install `novelrt` and fixes the install step for the main project.